### PR TITLE
proposed fix for map centering

### DIFF
--- a/js/drive.js
+++ b/js/drive.js
@@ -66,6 +66,10 @@ function createLine() {
 }
 
 function changeCenter(index) {
+
+    // Set center to a subsample of the line, say every 10th or 25th
+    let subsampleIndex = 100;
+
     let currentJson = geojsonPoint.features[0].geometry.coordinates.slice(0,index);
     let center = geojsonPoint.features[0].geometry.coordinates[index];
     let centerX = center[0];
@@ -86,8 +90,11 @@ function changeCenter(index) {
 
     // if you want to follow the point...
     if (followPoint === true) {
-	    map.jumpTo({
-	        center: [centerX, centerY]
-	    });
+      if (index % subsampleIndex == 0) {
+        console.log("changeCenter(index) = ", index, center)
+        map.jumpTo({
+  	        center: [centerX, centerY]
+  	    });
+      }
     }
 }


### PR DESCRIPTION
Related to https://github.com/whrcdontfearme22/kwethluk-demo/issues/1

---

This is some tested to code to fix how the centering of the map during a walk or stroll.

This proposed fix  cannot solve all strolling paths.  The end user must decide the optimal number to subsample the coordinates to make a proper map centering.   

This does a `mod` calculation based on the `index` from the `scroll` event.  The firing of the `scroll` event will be somewhat noisy (e.g., did the user move the scroll bar or did they move the mouse wheel, or was it on mobile??).  It's possible that the `mod` calculation will miss some expected move events.

--- 

_Original_ 

![1](https://user-images.githubusercontent.com/118112/80253149-97ffde80-862d-11ea-8c2c-6eccdc863b34.gif)

---

empirically set value

![100](https://user-images.githubusercontent.com/118112/80253159-9a623880-862d-11ea-9037-7dcfa6665875.gif)

